### PR TITLE
Log4jv2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/
+dynalog
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 Basically, I want a server that can dynamically generate log4j configs.
 
-Siple API that takes a base config file (or empty?) and then adds the different lines.
+Simple API that takes a base config file (or empty?) and then adds the different lines.
 
 People should be able to provide a base log4j template (ala codepen - https://codepen.io/kasei-dis/pen/JjYjwza) that they can append trace levels to.
 
 ## Usage
 
 ```shell
-curl https://dyna.log/metabase?trace=metabase.query-processor
+curl https://log4j.us/templates/metabase?trace=metabase.query-processor,metabase.driver
 ```
 
 Spits out the [default Metabase](https://raw.githubusercontent.com/metabase/metabase/891e128b1f3dfad7e73250e54108148cba491678/resources/log4j.properties) log4j + `metabase.query-processor` set to trace.

--- a/dynalog.go
+++ b/dynalog.go
@@ -15,6 +15,10 @@ import (
 type LogProperties struct {
 	Trace []string
 	Debug []string
+	Info []string
+	Warn []string
+	Error [] string
+	Fatal []string
 }
 
 func (lp LogProperties) any() bool {
@@ -31,6 +35,46 @@ func findTemplate(name string) (string, error) {
 		return "", fmt.Errorf("Could not find template `%s`", name)
 	}
 	return matches[0], nil
+}
+
+func addAllLoggingLevels(props LogProperties) (logLines []byte) {
+	// Append the different logging types
+	for _, c := range props.Trace {
+		line := fmt.Sprintf("log4j.logger.%s=TRACE\n", c)
+		logLines = append(logLines, line...)
+	}
+
+	// TODO: DRY this up
+	for _, c := range props.Debug {
+		line := fmt.Sprintf("log4j.logger.%s=DEBUG\n", c)
+		logLines = append(logLines, line...)
+	}
+
+	// TODO: DRY this up
+	for _, c := range props.Info {
+		line := fmt.Sprintf("log4j.logger.%s=INFO\n", c)
+		logLines = append(logLines, line...)
+	}
+
+	// TODO: DRY this up
+	for _, c := range props.Warn {
+		line := fmt.Sprintf("log4j.logger.%s=WARN\n", c)
+		logLines = append(logLines, line...)
+	}
+
+	// TODO: DRY this up
+	for _, c := range props.Error {
+		line := fmt.Sprintf("log4j.logger.%s=ERROR\n", c)
+		logLines = append(logLines, line...)
+	}
+
+	// TODO: DRY this up
+	for _, c := range props.Fatal {
+		line := fmt.Sprintf("log4j.logger.%s=FATAL\n", c)
+		logLines = append(logLines, line...)
+	}
+
+	return logLines
 }
 
 func buildLog4j(template string, props LogProperties) ([]byte, error) {
@@ -51,18 +95,7 @@ func buildLog4j(template string, props LogProperties) ([]byte, error) {
 	}
 
 	data = append(data, "\n\n## DYNALOG CUSTOM LOGGING LEVELS ENABLED 🚀 \n"...)
-
-	// Append the different logging types
-	for _, c := range props.Trace {
-		line := fmt.Sprintf("log4j.logger.%s=TRACE\n", c)
-		data = append(data, line...)
-	}
-
-	// TODO: DRY this up
-	for _, c := range props.Debug {
-		line := fmt.Sprintf("log4j.logger.%s=DEBUG\n", c)
-		data = append(data, line...)
-	}
+	data = append(data, addAllLoggingLevels(props)...)
 
 	return data, nil
 }
@@ -74,6 +107,18 @@ func buildLogProperties(c *gin.Context) LogProperties {
 	}
 	if len(c.Query("debug")) > 0 {
 		lp.Debug = strings.Split(c.Query("debug"), ",")
+	}
+	if len(c.Query("info")) > 0 {
+		lp.Info = strings.Split(c.Query("info"), ",")
+	}
+	if len(c.Query("warn")) > 0 {
+		lp.Warn = strings.Split(c.Query("warn"), ",")
+	}
+	if len(c.Query("error")) > 0 {
+		lp.Error = strings.Split(c.Query("error"), ",")
+	}
+	if len(c.Query("fatal")) > 0 {
+		lp.Fatal = strings.Split(c.Query("fatal"), ",")
 	}
 
 	return lp

--- a/dynalog.go
+++ b/dynalog.go
@@ -1,136 +1,24 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
-	"path/filepath"
 	"strings"
+	"text/template"
 
 	"github.com/gin-gonic/contrib/static"
 	"github.com/gin-gonic/gin"
 )
 
-// LogProperties define a desired logging structure
-type LogProperties struct {
-	Trace []string
-	Debug []string
-	Info []string
-	Warn []string
-	Error [] string
-	Fatal []string
-}
-
-func (lp LogProperties) any() bool {
-	return len(lp.Trace) != 0 || len(lp.Debug) != 0
-}
-
-func findTemplate(name string) (string, error) {
-	path := fmt.Sprintf("templates/%s.log4j.properties", name)
-	matches, err := filepath.Glob(path)
-	if err != nil {
-		return "", err
-	}
-	if len(matches) == 0 {
-		return "", fmt.Errorf("Could not find template `%s`", name)
-	}
-	return matches[0], nil
-}
-
-func addAllLoggingLevels(props LogProperties) (logLines []byte) {
-	// Append the different logging types
-	for _, c := range props.Trace {
-		line := fmt.Sprintf("log4j.logger.%s=TRACE\n", c)
-		logLines = append(logLines, line...)
-	}
-
-	// TODO: DRY this up
-	for _, c := range props.Debug {
-		line := fmt.Sprintf("log4j.logger.%s=DEBUG\n", c)
-		logLines = append(logLines, line...)
-	}
-
-	// TODO: DRY this up
-	for _, c := range props.Info {
-		line := fmt.Sprintf("log4j.logger.%s=INFO\n", c)
-		logLines = append(logLines, line...)
-	}
-
-	// TODO: DRY this up
-	for _, c := range props.Warn {
-		line := fmt.Sprintf("log4j.logger.%s=WARN\n", c)
-		logLines = append(logLines, line...)
-	}
-
-	// TODO: DRY this up
-	for _, c := range props.Error {
-		line := fmt.Sprintf("log4j.logger.%s=ERROR\n", c)
-		logLines = append(logLines, line...)
-	}
-
-	// TODO: DRY this up
-	for _, c := range props.Fatal {
-		line := fmt.Sprintf("log4j.logger.%s=FATAL\n", c)
-		logLines = append(logLines, line...)
-	}
-
-	return logLines
-}
-
-func buildLog4j(template string, props LogProperties) ([]byte, error) {
-	filename, err := findTemplate(template)
-	if err != nil {
-		fmt.Println("Could not find template: ", err)
-		return nil, err
-	}
-	data, err := ioutil.ReadFile(filename)
-	if err != nil {
-		fmt.Println("File reading error", err)
-		return nil, err
-	}
-
-	// If no custom levels are provide, just return the initial file
-	if !props.any() {
-		return data, nil
-	}
-
-	data = append(data, "\n\n## DYNALOG CUSTOM LOGGING LEVELS ENABLED 🚀 \n"...)
-	data = append(data, addAllLoggingLevels(props)...)
-
-	return data, nil
-}
-
-func buildLogProperties(c *gin.Context) LogProperties {
-	lp := LogProperties{}
-	if len(c.Query("trace")) > 0 {
-		lp.Trace = strings.Split(c.Query("trace"), ",")
-	}
-	if len(c.Query("debug")) > 0 {
-		lp.Debug = strings.Split(c.Query("debug"), ",")
-	}
-	if len(c.Query("info")) > 0 {
-		lp.Info = strings.Split(c.Query("info"), ",")
-	}
-	if len(c.Query("warn")) > 0 {
-		lp.Warn = strings.Split(c.Query("warn"), ",")
-	}
-	if len(c.Query("error")) > 0 {
-		lp.Error = strings.Split(c.Query("error"), ",")
-	}
-	if len(c.Query("fatal")) > 0 {
-		lp.Fatal = strings.Split(c.Query("fatal"), ",")
-	}
-
-	return lp
-}
-
 func main() {
+	funcMap := template.FuncMap{"ToUpper": strings.ToUpper}
 	r := gin.Default()
 
 	// ForceSSL in production
 	r.Use(ForceSSL(Options{
 		SSLProxyHeaders: map[string]string{"X-Forwarded-Proto": "https"},
-		IsDevelopment: gin.Mode() != gin.ReleaseMode,
+		IsDevelopment:   gin.Mode() != gin.ReleaseMode,
 	}))
 
 	// Basic site placeholder
@@ -145,6 +33,24 @@ func main() {
 			c.String(http.StatusBadRequest, fmt.Sprintf("bad request: %s", err))
 		}
 		c.String(http.StatusOK, string(logFile))
+	})
+
+	// Now supporting log4jv2
+	r.GET("/v2/templates/:name", func(c *gin.Context) {
+		n := c.Param("name")
+		ll := buildLogLevelsFromRequestParams(c)
+
+		templateName := fmt.Sprintf("%s.log4j.xml", n)
+		t, err := template.New(templateName).Funcs(funcMap).ParseFiles("./templates/" + templateName)
+		if err != nil {
+			c.String(http.StatusBadRequest, fmt.Sprintf("template not found"))
+			return
+		}
+
+		var result bytes.Buffer
+		t.Execute(&result, ll)
+		c.String(http.StatusOK, result.String())
+
 	})
 
 	r.Run() // listen and serve on 0.0.0.0:8080 (for windows "localhost:8080")

--- a/log4jv1.go
+++ b/log4jv1.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// LogProperties define a desired logging structure
+type LogProperties struct {
+	Trace []string
+	Debug []string
+	Info  []string
+	Warn  []string
+	Error []string
+	Fatal []string
+}
+
+func (lp LogProperties) any() bool {
+	return len(lp.Trace) != 0 || len(lp.Debug) != 0
+}
+
+func buildLogProperties(c *gin.Context) LogProperties {
+	lp := LogProperties{}
+	if len(c.Query("trace")) > 0 {
+		lp.Trace = strings.Split(c.Query("trace"), ",")
+	}
+	if len(c.Query("debug")) > 0 {
+		lp.Debug = strings.Split(c.Query("debug"), ",")
+	}
+	if len(c.Query("info")) > 0 {
+		lp.Info = strings.Split(c.Query("info"), ",")
+	}
+	if len(c.Query("warn")) > 0 {
+		lp.Warn = strings.Split(c.Query("warn"), ",")
+	}
+	if len(c.Query("error")) > 0 {
+		lp.Error = strings.Split(c.Query("error"), ",")
+	}
+	if len(c.Query("fatal")) > 0 {
+		lp.Fatal = strings.Split(c.Query("fatal"), ",")
+	}
+
+	return lp
+}
+
+func findTemplate(name string) (string, error) {
+	path := fmt.Sprintf("templates/%s.log4j.properties", name)
+	matches, err := filepath.Glob(path)
+	if err != nil {
+		return "", err
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("Could not find template `%s`", name)
+	}
+	return matches[0], nil
+}
+
+func addAllLoggingLevels(props LogProperties) (logLines []byte) {
+	// Append the different logging types
+	for _, c := range props.Trace {
+		line := fmt.Sprintf("log4j.logger.%s=TRACE\n", c)
+		logLines = append(logLines, line...)
+	}
+
+	// TODO: DRY this up
+	for _, c := range props.Debug {
+		line := fmt.Sprintf("log4j.logger.%s=DEBUG\n", c)
+		logLines = append(logLines, line...)
+	}
+
+	// TODO: DRY this up
+	for _, c := range props.Info {
+		line := fmt.Sprintf("log4j.logger.%s=INFO\n", c)
+		logLines = append(logLines, line...)
+	}
+
+	// TODO: DRY this up
+	for _, c := range props.Warn {
+		line := fmt.Sprintf("log4j.logger.%s=WARN\n", c)
+		logLines = append(logLines, line...)
+	}
+
+	// TODO: DRY this up
+	for _, c := range props.Error {
+		line := fmt.Sprintf("log4j.logger.%s=ERROR\n", c)
+		logLines = append(logLines, line...)
+	}
+
+	// TODO: DRY this up
+	for _, c := range props.Fatal {
+		line := fmt.Sprintf("log4j.logger.%s=FATAL\n", c)
+		logLines = append(logLines, line...)
+	}
+
+	return logLines
+}
+
+func buildLog4j(template string, props LogProperties) ([]byte, error) {
+	filename, err := findTemplate(template)
+	if err != nil {
+		fmt.Println("Could not find template: ", err)
+		return nil, err
+	}
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		fmt.Println("File reading error", err)
+		return nil, err
+	}
+
+	// If no custom levels are provide, just return the initial file
+	if !props.any() {
+		return data, nil
+	}
+
+	data = append(data, "\n\n## DYNALOG CUSTOM LOGGING LEVELS ENABLED 🚀 \n"...)
+	data = append(data, addAllLoggingLevels(props)...)
+
+	return data, nil
+}

--- a/log4jv2.go
+++ b/log4jv2.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// LogLevel is a single class name/log level pair
+type LogLevel struct {
+	Name  string
+	Level string
+}
+
+var logLevels = []string{"trace", "debug", "info", "warn", "error", "fatal"}
+
+func buildLogLevelsFromRequestParams(c *gin.Context) (ll []LogLevel) {
+	for _, level := range logLevels {
+		if len(c.Query(level)) > 0 {
+			for _, name := range strings.Split(c.Query(level), ",") {
+				ll = append(ll, LogLevel{name, level})
+			}
+		}
+	}
+
+	return ll
+}

--- a/public/index.html
+++ b/public/index.html
@@ -28,10 +28,7 @@
         <h6 class="examples-header">Examples</h6>
         <ul>
           <li>
-            <code>DEBUG</code> console logging –
-            <a href="/templates/consoledebug"
-              >https://log4j.us/templates/consoledebug</a
-            >
+            <code>DEBUG</code> console logging – <a href="/templates/consoledebug">https://log4j.us/templates/consoledebug</a>
           </li>
           <pre><code>log4j.rootLogger=DEBUG, console
 
@@ -42,10 +39,7 @@ log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{YYYY-MM-dd HH:mm:ss} \u001b[1m%p %c{2}\u001b[0m :: %m%n</code></pre>
 
           <li>
-            <code>DEBUG + TRACE</code> level logging –
-            <a href="/templates/consoledebug?trace=some.namespace"
-              >https://log4j.us/templates/consoledebug?trace=some.namespace</a
-            >
+            <code>DEBUG + TRACE</code> level logging – <a href="/templates/consoledebug?trace=some.namespace">https://log4j.us/templates/consoledebug?trace=some.namespace</a>
           </li>
           <pre><code>log4j.rootLogger=DEBUG, console
 
@@ -59,10 +53,7 @@ log4j.appender.console.layout.ConversionPattern=%d{YYYY-MM-dd HH:mm:ss} \u001b[1
 log4j.logger.some.namespace=TRACE</code></pre>
           <li>
             Built-in templates –
-            <a
-              href="/templates/metabase?trace=metabase.query-processor,metabase.driver"
-              >https://log4j.us/templates/metabase?trace=metabase.query-processor,metabase.driver</a
-            >
+            <a href="/templates/metabase?trace=metabase.query-processor,metabase.driver">https://log4j.us/templates/metabase?trace=metabase.query-processor,metabase.driver</a>
           </li>
           <pre><code>log4j.rootLogger=WARN, console
 log4j.debug=true
@@ -98,6 +89,36 @@ log4j.logger.com.mchange=ERROR
 ## DYNALOG CUSTOM LOGGING LEVELS ENABLED 🚀 
 log4j.logger.metabase.query-processor=TRACE
 log4j.logger.metabase.driver=TRACE</code></pre>
+
+          <li>
+            Log4j 2 Support – <a href="/v2/templates/metabase?trace=metabase.sync">https://log4j.us/v2/templates/metabase?trace=metabase.sync</a>
+          </li>
+          <pre><code>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
+&lt;Configuration&gt;
+    &lt;Appenders&gt;
+        &lt;Console name=&quot;STDOUT&quot; target=&quot;SYSTEM_OUT&quot;&gt;
+            &lt;PatternLayout pattern=&quot;%d %p %c{2} :: %m%n&quot;&gt;
+                &lt;replace regex=&quot;:basic-auth \\[.*\\]&quot; replacement=&quot;:basic-auth [redacted]&quot;/&gt;
+            &lt;/PatternLayout&gt;
+        &lt;/Console&gt;
+    &lt;/Appenders&gt;
+
+    &lt;Loggers&gt;
+        &lt;Logger name=&quot;metabase&quot; level=&quot;INFO&quot;/&gt;
+        &lt;Logger name=&quot;metabase.plugins&quot; level=&quot;DEBUG&quot;/&gt;
+        &lt;Logger name=&quot;metabase.middleware&quot; level=&quot;DEBUG&quot;/&gt;
+        &lt;Logger name=&quot;metabase.query-processor.async&quot; level=&quot;DEBUG&quot;/&gt;
+        &lt;Logger name=&quot;com.mchange&quot; level=&quot;ERROR&quot;/&gt;
+        &lt;!-- DYNALOG CUSTOM LOGGING LEVELS ENABLED 🚀 --&gt;
+        
+        &lt;Logger name=&quot;metabase.sync&quot; level=&quot;TRACE&quot;/&gt;
+        
+
+        &lt;Root level=&quot;WARN&quot;&gt;
+            &lt;AppenderRef ref=&quot;STDOUT&quot;/&gt;
+        &lt;/Root&gt;
+    &lt;/Loggers&gt;
+&lt;/Configuration&gt;</code></pre>
         </ul>
       </div>
     </div>

--- a/templates/metabase.log4j.xml
+++ b/templates/metabase.log4j.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d %p %c{2} :: %m%n">
+                <replace regex=":basic-auth \\[.*\\]" replacement=":basic-auth [redacted]"/>
+            </PatternLayout>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="metabase" level="INFO"/>
+        <Logger name="metabase.plugins" level="DEBUG"/>
+        <Logger name="metabase.middleware" level="DEBUG"/>
+        <Logger name="metabase.query-processor.async" level="DEBUG"/>
+        <Logger name="com.mchange" level="ERROR"/>
+        {{if . }}<!-- DYNALOG CUSTOM LOGGING LEVELS ENABLED 🚀 -->{{end}}
+        {{range . }}
+        <Logger name="{{ .Name }}" level="{{ .Level | ToUpper }}"/>
+        {{ end }}
+
+        <Root level="WARN">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Restructure things a bit so we have log4jv1 and v2 functions in separate files.

Also make building the loglevels struct a little less hard-coded. Resolves #2 

Add support for v2 XML files. Resolves #3 